### PR TITLE
Express urlencoded  middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "babel-jest": "^24.9.0",
     "bcrypt": "^4.0.1",
-    "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "babel-jest": "^24.9.0",
     "bcrypt": "^4.0.1",
+    "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.5",
     "dotenv": "^8.2.0",

--- a/server/app.js
+++ b/server/app.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const compression = require('compression');
 const { join } = require('path');
+const bodyParser = require('body-parser');
 
 const controller = require('./controllers');
 
 const app = express();
-
+app.use(bodyParser.urlencoded({ extended: false }));
 app.disable('x-powered-by');
 app.set('port', process.env.PORT || 5000);
 

--- a/server/app.js
+++ b/server/app.js
@@ -1,16 +1,16 @@
 const express = require('express');
 const compression = require('compression');
 const { join } = require('path');
-const bodyParser = require('body-parser');
 
 const controller = require('./controllers');
 
 const app = express();
-app.use(bodyParser.urlencoded({ extended: false }));
+
 app.disable('x-powered-by');
 app.set('port', process.env.PORT || 5000);
 
 app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
 app.use(compression());
 app.use('/api/v1/', controller);
 


### PR DESCRIPTION
add express.urlencoded method  to recognize the incoming Request Object as strings or arrays. This method is called as a middleware in the appl using the code:
```js
app.use(express.urlencoded());
```
relates #37