### PR TITLE
fix bug in admin project page (github link)

### DIFF
--- a/client/src/containers/AdminProjectPage/index.js
+++ b/client/src/containers/AdminProjectPage/index.js
@@ -114,7 +114,7 @@ class AdminProject extends Component {
                       imgUrl={item.img_url}
                       name={item.name}
                       description={item.description}
-                      githbUrl={item.github_url}
+                      githbUrl={item.github_link}
                       websiteLink={item.website_link}
                       projectId={item.id}
                       editCard={`/admin/cohorts/${cohortId}/projects/${item.id}/edit`}


### PR DESCRIPTION
relates #162

fix bug in admin project page : 
github link in the card undefined 

```js
<List
                dataSource={dataList}
                renderItem={(item) => (
                  <List.Item key={item.id} className="admin-list-card">
                    <AdminCard
                      imgUrl={item.img_url}
                      name={item.name}
                      description={item.description}
                      githbUrl={item.github_url}  // must be  github_link
                      websiteLink={item.website_link}
                      projectId={item.id}
                      editCard={`/admin/cohorts/${cohortId}/projects/${item.id}/edit`}
                      deleteCard={this.deleteProject}
                    />
                  </List.Item>
                )}
              />
```